### PR TITLE
Accept ReadonlyArray in the TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare const arrayMove: {
 	//=> ['b', 'a', 'c']
 	```
 	*/
-	<ValueType>(array: ValueType[], from: number, to: number): ValueType[];
+	<ValueType>(array: ReadonlyArray<ValueType>, from: number, to: number): ValueType[];
 
 	/**
 	Moves the item to the new position in the input array. Useful for huge arrays where absolute performance is needed.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,3 +4,6 @@ import arrayMove = require('.');
 expectType<string[]>(arrayMove(['a', 'b', 'c'], 1, 2));
 expectType<number[]>(arrayMove([1, 2, 3], 1, 2));
 expectType<void>(arrayMove.mutate(['a', 'b', 'c'], 1, 2));
+
+expectType<number[]>(arrayMove([1, 2, 3] as ReadonlyArray<number>, 1, 2));
+expectType<string[]>(arrayMove(['a', 'b', 'c'] as ReadonlyArray<string>, 1, 2));


### PR DESCRIPTION
Since the default `arrayMove` function does not mutate the `array` parameter, I think it should be typed as "readonly".

```ts
import arrayMove from "array-move";

const mutableList: Array<number> = [1, 2, 3, 4];
const a1 = arrayMove(mutableList, 0, 1); // ✅

const readonlyList: ReadonlyArray<number> = [1, 2, 3, 4];
const b1 = arrayMove(readonlyList, 0, 1); // ❌ error!
// Argument of type 'readonly number[]' is not assignable to parameter of type 'number[]'.
//   The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type 'number[]'.ts(2345)
```
[codesandbox example](https://codesandbox.io/s/array-move-with-readonlyarray-5n3fo)

I added two test cases before changing the `.d.ts` and I expectedly got the following errors:

```
npx tsd

  index.test-d.ts:8:31
  ✖  8:31  Argument of type readonly number[] is not assignable to parameter of type number[].
  The type readonly number[] is readonly and cannot be assigned to the mutable type number[].  
  ✖  9:31  Argument of type readonly string[] is not assignable to parameter of type string[].
  The type readonly string[] is readonly and cannot be assigned to the mutable type string[].  

  2 errors
```

By typing the argument as `ReadonlyArray<T>` the function accepts both readonly and non-readonly arrays.
