### PR TITLE
fix type issue and eslint warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ export function arrayMoveMutable(array, fromIndex, toIndex) {
 }
 
 export function arrayMoveImmutable(array, fromIndex, toIndex) {
-	array = [...array];
-	arrayMoveMutable(array, fromIndex, toIndex);
-	return array;
+	const newArray = [...array];
+	arrayMoveMutable(newArray, fromIndex, toIndex);
+	return newArray;
 }


### PR DESCRIPTION
there was reassignment done on the function parameter. that's considered an error by typescript, since this param is declared as read-only. also some linting rules prohibit reassigning function parameters.

this PR just declares a new local variable `newArray` and returns that instead.

this fixes:
- ESLint: Assignment to function parameter 'array'.(no-param-reassign)
- TS2345: Argument of type 'readonly ValueType[]' is not assignable to parameter of type 'unknown[]'.   The type 'readonly ValueType[]' is 'readonly' and cannot be assigned to the mutable type 'unknown[]'.
- TS4104: The type 'readonly ValueType[]' is 'readonly' and cannot be assigned to the mutable type 'ValueType[]'.